### PR TITLE
Fix nRF51822 datasheet link

### DIFF
--- a/docs/device.md
+++ b/docs/device.md
@@ -24,7 +24,7 @@ On board the micro:bit there is already:
         the micro:bit.
     </p>
     <p>
-        <a target="_blank" href="../resources/datasheets/nrf51822.pdf" class="btn btn-lg btn-outline">
+        <a target="_blank" href="../resources/datasheets/nRF51822.pdf" class="btn btn-lg btn-outline">
             Datasheet
         </a>
     </p>


### PR DESCRIPTION
Currently the link from https://lancaster-university.github.io/microbit-docs/device/ gives a 404 error.