### PR TITLE
Fix broken link to nordic datasheet.

### DIFF
--- a/docs/ubit/radio.md
+++ b/docs/ubit/radio.md
@@ -2,7 +2,7 @@
 
 ##Overview
 
-The central processor unit (CPU) on the micro:bit is a Nordic Semiconductor [nRF51822](../resources/datasheets/nrf51822.pdf). In addition to being a general purpose
+The central processor unit (CPU) on the micro:bit is a Nordic Semiconductor [nRF51822](../resources/datasheets/nRF51822.pdf). In addition to being a general purpose
 computer processor, this chip also contains a built-in 2.4GHz radio module.  This radio can be configured in a number of
 ways, and is primarily designed to run the Bluetooth Low Energy (BLE) protocol. However, it can also be placed into a much
 simpler mode of operation based that allows simple, direct micro:bit to micro:bit communication.


### PR DESCRIPTION
Very small PR, basically in the [https://lancaster-university.github.io/microbit-docs/ubit/radio/](https://lancaster-university.github.io/microbit-docs/ubit/radio/) page the datasheet link is broken due to capitalisation.