### PR TITLE
UART example: Return from onConnect() when disconnected

### DIFF
--- a/docs/ble/uart-service.md
+++ b/docs/ble/uart-service.md
@@ -40,7 +40,7 @@ void onConnected(MicroBitEvent e)
     // my client will send ASCII strings terminated with the colon character
     ManagedString eom(":");
     
-    while(1) {
+    while (connected == 1) {
         ManagedString msg = uart->readUntil(eom);
         uBit.display.scroll(msg);
     }


### PR DESCRIPTION
Update the UART example to return from onConnect() when disconnected
to allow multiple connect/disconnects.